### PR TITLE
Add new signature subpacket types

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -117,6 +117,8 @@ Packet.SIGNATURE_SUBPACKET_TYPES = {
     30: "Features",
     31: "Signature Target",
     32: "Embedded Signature",
+    33: "Issuer Fingerprint",
+    34: "Preferred AEAD Algorithms",
 };
 
 Packet.KEYSERVER_PREFERENCES = {


### PR DESCRIPTION
Some new signature subpacket fields from rfc4880bis

I came across this here:
https://lists.gnupg.org/pipermail/gnupg-users/2018-January/059881.html

Full text with description of fields:
https://tools.ietf.org/html/draft-ietf-openpgp-rfc4880bis-04

gpg is generating signatures that include some of these fields now. Hopefully this change will help people with debugging (searching for "pgp subpacket 33" currently yields a pile of bug reports related to this new behavior). 